### PR TITLE
bugfix on LenetMnist example

### DIFF
--- a/src/test/scala/org/deeplearning4s/mnist/example/LeNetMnistExample.scala
+++ b/src/test/scala/org/deeplearning4s/mnist/example/LeNetMnistExample.scala
@@ -25,7 +25,7 @@ import org.deeplearning4j.optimize.listeners.ScoreIterationListener
 import org.deeplearning4s.layers.convolutional.Convolution2D
 import org.deeplearning4s.layers.pooling.MaxPooling2D
 import org.deeplearning4s.layers.{Dense, DenseOutput}
-import org.deeplearning4s.models.{NeuralNet, Sequential}
+import org.deeplearning4s.models.{Sequential}
 import org.deeplearning4s.optimizers.SGD
 import org.deeplearning4s.regularizers.l2
 import org.nd4j.linalg.api.ndarray.INDArray


### PR DESCRIPTION
Got the following error when building ScalNet for scala 2.10, MacOSX 10.11:

```
[ERROR] /Users/tuannguyen/Develop/projects/github/ScalNet/src/test/scala/org/deeplearning4s/mnist/example/LeNetMnistExample.scala:28: error: object NeuralNet is not a member of package org.deeplearning4s.models
[INFO] import org.deeplearning4s.models.{NeuralNet, Sequential}
```

Full log: 
[build.txt](https://github.com/deeplearning4j/ScalNet/files/457235/build.txt)

