### PR TITLE
Multi-version SBT build, using sbt-pomreader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,3 @@
+scalaVersion := "2.11.8"
+
+crossScalaVersions := Seq("2.10.6", "2.11.8")

--- a/project/ScalNetBuild.scala
+++ b/project/ScalNetBuild.scala
@@ -1,0 +1,2 @@
+import sbt._
+object ScalNetBuild extends com.typesafe.sbt.pom.PomBuild

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-pom-reader" % "2.0.0")


### PR DESCRIPTION
Offers an unobtrusive sbt build alternative.

Completely incompatible with https://github.com/deeplearning4j/ScalNet/pull/10 which mangles artifact names in a way that's not recoverable from sbt.