### PR TITLE
Prevent duplicate/redundant dependencies using maven-lint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,31 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.lewisd</groupId>
+        <artifactId>lint-maven-plugin</artifactId>
+        <version>0.0.8</version>
+        <configuration>
+          <failOnViolation>true</failOnViolation>
+          <onlyRunRules>
+            <rule>DuplicateDep</rule>
+            <rule>RedundantDepVersion</rule>
+            <rule>RedundantPluginVersion</rule>
+            <rule>VersionProp</rule>
+            <rule>DotVersionProperty</rule>
+          </onlyRunRules>
+          <xmlOutputFile>${project.build.directory}/maven-lint-result.xml</xmlOutputFile>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pom-lint</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
Avoids nd4j/#1345