### PR TITLE
Disable default automatic update of SNAPSHOT artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,19 @@
 
   <repositories>
     <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </snapshots>
+    </repository>
+
+    <repository>
       <id>scala-tools.org</id>
       <name>Scala-Tools Maven2 Repository</name>
       <url>http://scala-tools.org/repo-releases</url>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `<updatePolicy>never</updatePolicy>` on the SNAPSHOT repository to prevent interference with locally installed artifacts. They can still be pulled manually with `mvn -U ...`.

## How was this patch tested?

Build passes and SNAPSHOT artifacts do not get updated automatically anymore.