### PR TITLE
Introduce SKIP_BUILD mode to perform-release.sh script

### DIFF
--- a/perform-release.sh
+++ b/perform-release.sh
@@ -41,9 +41,9 @@ if [[ "${SKIP_BUILD}" == "0" ]]; then
 
     source change-scala-versions.sh 2.11
 fi
-git commit -a -m "Update to version $RELEASE_VERSION"
-git tag -a -m "scalnet-$RELEASE_VERSION" "scalnet-$RELEASE_VERSION"
-git tag -a -f -m "scalnet-$RELEASE_VERSION" "latest_release"
+git commit -s -a -m "Update to version $RELEASE_VERSION"
+git tag -s -a -m "scalnet-$RELEASE_VERSION" "scalnet-$RELEASE_VERSION"
+git tag -s -a -f -m "scalnet-$RELEASE_VERSION" "latest_release"
 
 sed -i "s/<nd4j.version>.*<\/nd4j.version>/<nd4j.version>$SNAPSHOT_VERSION<\/nd4j.version>/" pom.xml
 sed -i "s/<datavec.version>.*<\/datavec.version>/<datavec.version>$SNAPSHOT_VERSION<\/datavec.version>/" pom.xml
@@ -51,6 +51,6 @@ sed -i "s/<dl4j.version>.*<\/dl4j.version>/<dl4j.version>$SNAPSHOT_VERSION<\/dl4
 # back to a version stanza
 sed -i "s/<version>$RELEASE_VERSION<\/version>/<version>$SNAPSHOT_VERSION<\/version>/" pom.xml
 mvn versions:set -DallowSnapshots=true -DgenerateBackupPoms=false -DnewVersion=$SNAPSHOT_VERSION
-git commit -a -m "Update to version $SNAPSHOT_VERSION"
+git commit -s -a -m "Update to version $SNAPSHOT_VERSION"
 
 echo "Successfully performed release of version $RELEASE_VERSION ($SNAPSHOT_VERSION) to repository $STAGING_REPOSITORY"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -9,9 +9,7 @@ fi
 RELEASE_VERSION=$1
 SNAPSHOT_VERSION=$2
 STAGING_REPOSITORY=${3:-}
-if [[ -z ${SKIP_BUILD:-} ]]; then
-    SKIP_BUILD=0
-fi
+SKIP_BUILD=${SKIP_BUILD:-0}
 
 if [[ "$2" != *-SNAPSHOT ]]
 then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow updating the source code for a release before making the final build on the "latest_release" tag.

## How was this patch tested?

Build succeeds with source code modified by the script, with no reference to SNAPSHOT artifacts.