### PR TITLE
Update shell scripts to support Scala 2.12

### DIFF
--- a/change-scala-versions.sh
+++ b/change-scala-versions.sh
@@ -58,9 +58,6 @@ TO_VERSION=$(echo $TO_VERSION | perl -pe 's/.*?([0-9]+\.[0-9]+\.[0-9]+).*/\1/g')
 FROM_BINARY=_$FROM_BINARY
 TO_BINARY=_$TO_BINARY
 
-echo "$FROM_BINARY"
-echo "$TO_BINARY"
-
 sed_i() {
   sed -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
 }

--- a/change-scala-versions.sh
+++ b/change-scala-versions.sh
@@ -47,10 +47,10 @@ check_scala_version() {
 check_scala_version "$TO_BINARY"
 
 FROM_BINARY=$(awk -F '[<>]' '/artifactId/{print $3}' pom.xml | grep scalnet | cut -d '_' -f 2)
-FROM_BINARY_VERSION=scala$(echo "$FROM_BINARY" | sed 's/\.//g').version
+FROM_BINARY_VERSION=scala${FROM_BINARY//.}.version
 FROM_VERSION=$(grep -F -m 1 "$FROM_BINARY_VERSION" pom.xml); FROM_VERSION="${FROM_VERSION#*>}"; FROM_VERSION="${FROM_VERSION%<*}";
 
-TO_BINARY_VERSION=scala$(echo "$TO_BINARY" | sed 's/\.//g').version
+TO_BINARY_VERSION=scala${TO_BINARY//.}.version
 TO_VERSION=$(grep -F -m 1 "$TO_BINARY_VERSION" pom.xml); TO_VERSION="${TO_VERSION#*>}"; TO_VERSION="${TO_VERSION%<*}";
 
 FROM_BINARY=_$FROM_BINARY

--- a/change-scala-versions.sh
+++ b/change-scala-versions.sh
@@ -46,7 +46,7 @@ check_scala_version() {
 
 check_scala_version "$TO_BINARY"
 
-FROM_BINARY=$(awk -F '[<>]' '/artifactId/{print $3}' pom.xml | grep scalnet | cut -d '_' -f 2)
+FROM_BINARY=$(awk -F '[<>]' '/artifactId.*?scalnet_[0-9\.]+/{sub("scalnet_", ""); print $3}' pom.xml)
 FROM_BINARY_VERSION=scala${FROM_BINARY//.}.version
 FROM_VERSION=$(grep -F -m 1 "$FROM_BINARY_VERSION" pom.xml); FROM_VERSION="${FROM_VERSION#*>}"; FROM_VERSION="${FROM_VERSION%<*}";
 FROM_VERSION=$(echo $FROM_VERSION | perl -pe 's/.*?([0-9]+\.[0-9]+\.[0-9]+).*/\1/g')

--- a/change-scala-versions.sh
+++ b/change-scala-versions.sh
@@ -49,9 +49,11 @@ check_scala_version "$TO_BINARY"
 FROM_BINARY=$(awk -F '[<>]' '/artifactId/{print $3}' pom.xml | grep scalnet | cut -d '_' -f 2)
 FROM_BINARY_VERSION=scala${FROM_BINARY//.}.version
 FROM_VERSION=$(grep -F -m 1 "$FROM_BINARY_VERSION" pom.xml); FROM_VERSION="${FROM_VERSION#*>}"; FROM_VERSION="${FROM_VERSION%<*}";
+FROM_VERSION=$(echo $FROM_VERSION | perl -pe 's/.*?([0-9]+\.[0-9]+\.[0-9]+).*/\1/g')
 
 TO_BINARY_VERSION=scala${TO_BINARY//.}.version
 TO_VERSION=$(grep -F -m 1 "$TO_BINARY_VERSION" pom.xml); TO_VERSION="${TO_VERSION#*>}"; TO_VERSION="${TO_VERSION%<*}";
+TO_VERSION=$(echo $TO_VERSION | perl -pe 's/.*?([0-9]+\.[0-9]+\.[0-9]+).*/\1/g')
 
 FROM_BINARY=_$FROM_BINARY
 TO_BINARY=_$TO_BINARY

--- a/change-scala-versions.sh
+++ b/change-scala-versions.sh
@@ -21,9 +21,10 @@
 
 set -e
 
-VALID_VERSIONS=( 2.10 2.11 )
+VALID_VERSIONS=( 2.10 2.11 2.12 )
 SCALA_210_VERSION=$(grep -F -m 1 'scala210.version' pom.xml); SCALA_210_VERSION="${SCALA_210_VERSION#*>}"; SCALA_210_VERSION="${SCALA_210_VERSION%<*}";
 SCALA_211_VERSION=$(grep -F -m 1 'scala211.version' pom.xml); SCALA_211_VERSION="${SCALA_211_VERSION#*>}"; SCALA_211_VERSION="${SCALA_211_VERSION%<*}";
+SCALA_212_VERSION=$(grep -F -m 1 'scala212.version' pom.xml); SCALA_212_VERSION="${SCALA_212_VERSION#*>}"; SCALA_212_VERSION="${SCALA_212_VERSION%<*}";
 
 usage() {
   echo "Usage: $(basename $0) [-h|--help] <scala version to be used>
@@ -54,6 +55,11 @@ if [ $TO_VERSION = "2.11" ]; then
   TO_BINARY="_2\.11"
   FROM_VERSION=$SCALA_210_VERSION
   TO_VERSION=$SCALA_211_VERSION
+elif [ $TO_VERSION = "2.12" ]; then
+  FROM_BINARY="_2\.11"
+  TO_BINARY="_2\.12"
+  FROM_VERSION=$SCALA_211_VERSION
+  TO_VERSION=$SCALA_212_VERSION
 else
   FROM_BINARY="_2\.11"
   TO_BINARY="_2\.10"

--- a/perform-release.sh
+++ b/perform-release.sh
@@ -38,6 +38,8 @@ if [[ "${SKIP_BUILD}" == "0" ]]; then
     mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -DstagingRepositoryId=$STAGING_REPOSITORY -Dscalastyle.skip
     source change-scala-versions.sh 2.11
     mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -DstagingRepositoryId=$STAGING_REPOSITORY -Dscalastyle.skip
+    source change-scala-versions.sh 2.12
+    mvn clean deploy -Dgpg.executable=gpg2 -DperformRelease -Psonatype-oss-release -DskipTests -DstagingRepositoryId=$STAGING_REPOSITORY -Dscalastyle.skip
 
     source change-scala-versions.sh 2.11
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
     <!-- Scala 2.11.x -->
     <scala211.version>2.11.8</scala211.version>
     <scala211.binary.version>2.11</scala211.binary.version>
+    <!-- Scala 2.12.x -->
+    <scala212.version>2.12.3</scala212.version>
+    <scala212.binary.version>2.12</scala212.binary.version>
 
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.8</scala.version>


### PR DESCRIPTION
This PR is basically a duplicate of #34. As suggested by @agibsonccc, I am sending this pull request to be merged to this branch, instead of master.

## What changes were proposed in this pull request?

This PR adds scala 2.12.x as supported versions to `pom.xml` and `change-scala-versions.sh` to help maintainers when publishing artifiacts for scala 2.12.x to maven repository.

Also, this PR makes `change-scala-versions.sh` to auto-detect current scala version from `pom.xml` to make it easier to support future scala versions without pain.

## How was this patch tested?

I ran the following commands in shell, and the packaging & compiling & tests were completed successfully. (only after changing `nd4j.version` from `0.9.1-SNAPSHOT` to `0.9.0` in `pom.xml`).

```bash
$ ./change-scala-versions.sh 2.12
$ mvn package -Pscala-2.12.x
$ sbt compile
```
