### PR TITLE
In pom.xml add tags goals to tag goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,9 @@
                     <groupId>com.lewisd</groupId>
                     <artifactId>lint-maven-plugin</artifactId>
                     <versionRange>[0.0.11,)</versionRange>
-                    <goal>check</goal>
+                    <goals>
+                      <goal>check</goal>
+                    </goals>
                   </pluginExecutionFilter>
                   <action>
                     <ignore/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In main pom.xml was one case of tag goal without tags goals.
In case of import in Eclipse it get error:
Cannot parse lifecycle mapping metadata for maven project MavenProject: org.nd4j:nd4j:0.9.2-SNAPSHOT @ C:\Java_ws_E2\dl4j\dl4j\nd4j\pom.xml Cause: Unrecognised tag: 'goal' (position: START_TAG seen ...\r\n ... @9:15)

## How was this patch tested?

I check it manually.