### PR TITLE
Fixed sbt build being sometimes broken by surefire failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,11 @@
 language: scala
-scala:
-  - 2.11.12
-  - 2.10.7
+scala: dummy
 jdk: oraclejdk8
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean compile test
+  - sbt ++2.11.12 clean compile test
+  - sbt ++2.10.7 clean compile test
   - ./change-scala-versions.sh "2.11"
   - mvn -q clean package
   - ./change-scala-versions.sh "2.10"
   - mvn -q clean package
-
-cache:
-  directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt
-    - $HOME/.m2
-
-before_cache:
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
-  - find $HOME/.sbt        -name "*.lock"               -print -delete
-  - find $HOME/.m2         -name "*.lastUpdated"        -print -delete
-
-after_success:
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
-  - find $HOME/.sbt        -name "*.lock"               -print -delete
-  - find $HOME/.m2         -name "*.lastUpdated"        -print -delete

--- a/sbt-pom.xml
+++ b/sbt-pom.xml
@@ -62,7 +62,6 @@
                     <skipTests>true</skipTests>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 

--- a/sbt-pom.xml
+++ b/sbt-pom.xml
@@ -46,6 +46,7 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.basedir}/lib</outputDirectory>
+                            <includeScope>compile</includeScope>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
@@ -53,6 +54,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

On occasions (newly generated nd4j snapshots ?), the maven command invoked from sbt (sbt-pom.xml) would fail due to failed checks with maven-surefire-plugin, probably from dependencies or transitive deps.

Nd4j dependencies are then not updated and would result in a crash when running like this one:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGILL (0x4) at pc=0x00007fb0a7c718e5, pid=19027, tid=0x00007fb0e024a700
#
# JRE version: OpenJDK Runtime Environment (8.0_151-b12) (build 1.8.0_151-8u151-b12-0ubuntu0.16.04.2-b12)
# Java VM: OpenJDK 64-Bit Server VM (25.151-b12 mixed mode linux-amd64 compressed oops)
# Problematic frame:
# C  [libnd4jcpu.so+0x15b38e5]  nd4j::ops::OpRegistrator::registerOperationFloat(char const*, nd4j::ops::DeclarableOp<float>*)+0x215
#
```

Disabling surefire (like in a scala-maven build) fixes the issue:
```
<skipTests>true</skipTests>
```

## How was this patch tested?

Usually when running around 10 identical Travis builds against a branch, at least one would fail with this error. This is not the case anymore with this fix.